### PR TITLE
Reason for contact added to email; date/time if no subject line

### DIFF
--- a/HelloWorld.php
+++ b/HelloWorld.php
@@ -16,14 +16,11 @@
             max-width: 800px;
             min-width: 400px;
         }
-
         fieldset {
             margin: 1em 0;
             padding: 1em 0;
         }
-
         label {display: block;}
-
         .inputText, label {
             display: block;
             width: 60vw;
@@ -31,7 +28,6 @@
             max-width: 750px;
             margin: 0.5em auto;
         }
-
         .flexbox {
             display: flex;
             justify-content: space-between;
@@ -40,11 +36,9 @@
             max-width: 750px;
             margin: auto;
         }
-
         #submitEmail {
             height: min-content;
         }
-
         .small {font-size: 0.8em;}
         .italic {
             font-style: italic;
@@ -55,23 +49,9 @@
         }
     </style>
 </head>
-<body>
-    
+<body>    
     <form method="POST">
         <fieldset>
-            <!--<legend> <span class="bold">~(Optional)~ </span> What would you like to chat about? </legend>-->
-            <!--<label for="new" class="checkbox">-->
-            <!--    <input type="checkbox" id="new" name="concern" value="newProject">Let's talk about a new project</label>-->
-            <!--<label for="existing" class="checkbox">-->
-            <!--    <input type="checkbox" id="existing" name="concern" value="existingProject">Let's discuss a project we're already working on together</label>-->
-            <!--<label for="dev" class="checkbox">-->
-            <!--    <input type="checkbox" id="dev" name="concern" value="dev">I'm a developer and I have a question</label>-->
-            <!--<label for="general" class="checkbox">-->
-            <!--    <input type="checkbox" id="general" name="concern" value="general">I have a more general inquiry</label>-->
-            <!--<label for="other" class="checkbox">-->
-            <!--    <input type="checkbox" id="other" name="concern" value="other">Something else</label>-->
-            <!--<label for="hi" class="checkbox">-->
-            <!--    <input type="checkbox" id="hi" name="concern" value="hi">Just saying hi</label>-->
             <legend> <span class="bold">~(Optional)~ </span> What would you like to chat about? </legend>
             <label for="new" class="radio">
                 <input type="radio" id="new" name="concern" value="new">Let's talk about a new project</label>
@@ -85,7 +65,6 @@
                 <input type="radio" id="other" name="concern" value="other">Something else</label>
             <label for="hi" class="radio">
                 <input type="radio" id="hi" name="concern" value="hi">Just saying hi</label>
-
         </fieldset>
         <fieldset>
             <h2 style="color: red; background-color: white;">Refresh page before sending</h2>
@@ -113,7 +92,6 @@
                 <button type="submit" id="submitEmail">Send message</button>
             </div>
             <p class="small italic">I won't share your email address with anyone, and I won't use it for any purpose other than replying to the message you're sending me here. By sending me a message here, you're implicitly giving me the "ok" to reply to you at this email address.</p>
-            
         </fieldset>
     </form>
 


### PR DESCRIPTION
If the user doesn't add a subject line, the default subject line will be appended with the current date and time (MST) so subjectless emails don't all collapse into one "thread".

The radio button the user selects as reason for contact will now be noted in the email body. (If no radio button was selected, this part of the email body will be omitted.)