### PR TITLE
Added BCC; added my gmail as add'l Reply-To

### DIFF
--- a/HelloWorld.php
+++ b/HelloWorld.php
@@ -16,11 +16,14 @@
             max-width: 800px;
             min-width: 400px;
         }
+
         fieldset {
             margin: 1em 0;
             padding: 1em 0;
         }
+
         label {display: block;}
+
         .inputText, label {
             display: block;
             width: 60vw;
@@ -28,6 +31,7 @@
             max-width: 750px;
             margin: 0.5em auto;
         }
+
         .flexbox {
             display: flex;
             justify-content: space-between;
@@ -36,9 +40,11 @@
             max-width: 750px;
             margin: auto;
         }
+
         #submitEmail {
             height: min-content;
         }
+
         .small {font-size: 0.8em;}
         .italic {
             font-style: italic;
@@ -49,9 +55,23 @@
         }
     </style>
 </head>
-<body>    
+<body>
+    
     <form method="POST">
         <fieldset>
+            <!--<legend> <span class="bold">~(Optional)~ </span> What would you like to chat about? </legend>-->
+            <!--<label for="new" class="checkbox">-->
+            <!--    <input type="checkbox" id="new" name="concern" value="newProject">Let's talk about a new project</label>-->
+            <!--<label for="existing" class="checkbox">-->
+            <!--    <input type="checkbox" id="existing" name="concern" value="existingProject">Let's discuss a project we're already working on together</label>-->
+            <!--<label for="dev" class="checkbox">-->
+            <!--    <input type="checkbox" id="dev" name="concern" value="dev">I'm a developer and I have a question</label>-->
+            <!--<label for="general" class="checkbox">-->
+            <!--    <input type="checkbox" id="general" name="concern" value="general">I have a more general inquiry</label>-->
+            <!--<label for="other" class="checkbox">-->
+            <!--    <input type="checkbox" id="other" name="concern" value="other">Something else</label>-->
+            <!--<label for="hi" class="checkbox">-->
+            <!--    <input type="checkbox" id="hi" name="concern" value="hi">Just saying hi</label>-->
             <legend> <span class="bold">~(Optional)~ </span> What would you like to chat about? </legend>
             <label for="new" class="radio">
                 <input type="radio" id="new" name="concern" value="new">Let's talk about a new project</label>
@@ -65,6 +85,7 @@
                 <input type="radio" id="other" name="concern" value="other">Something else</label>
             <label for="hi" class="radio">
                 <input type="radio" id="hi" name="concern" value="hi">Just saying hi</label>
+
         </fieldset>
         <fieldset>
             <h2 style="color: red; background-color: white;">Refresh page before sending</h2>
@@ -92,6 +113,7 @@
                 <button type="submit" id="submitEmail">Send message</button>
             </div>
             <p class="small italic">I won't share your email address with anyone, and I won't use it for any purpose other than replying to the message you're sending me here. By sending me a message here, you're implicitly giving me the "ok" to reply to you at this email address.</p>
+            
         </fieldset>
     </form>
 
@@ -134,10 +156,11 @@
         }
     
     $headers = 'From: ' . $_POST['userEmail'] . "\r\n" .
-        'Reply-To: weatherheadonline@gmail.com' . "\r\n" .
-        'Content-type: text/html' . "\r\n";
+        'Reply-To: weatherheadonline@gmail.com, ' . $_POST['userEmail'] . "\r\n" .
+        'Content-type: text/html' . "\r\n" . 
+        'BCC: eddie.weatherhead@gmail.com' . "\r\n";   // in production, change this to WO@g.com & change "to" and "reply-to" to e@WO.com
 
-    $to = 'weatherheadonline@gmail.com';
+    $to = 'Eddie <weatherheadonline@gmail.com>';
     mail($to, $subject, $message, $headers);
 
 ?>


### PR DESCRIPTION
User's email will get BCC'd to another email address of mine. This way, when their email gets sent to eddie@weatherheadonline.com, it can also get sent to weatherheadonline@gmail.com, so that I will get a notification.

The reply-to field already contained the user's email address; now it also contains my email address. Seems like maybe a good policy? 